### PR TITLE
Bugfix: Quicklinks newline

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -120,16 +120,16 @@ available.
 <div class="block">
   <h3>Quick Links</h3>
   <div class="content">
-<p>
-<a href="http://docs.sympy.org/">Documentation</a></br>
-<a href="http://code.google.com/p/sympy/downloads/list">Downloads (source tarballs)</a></br>
-<a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (packages for distributions)</a></br>
-<a href="http://github.com/sympy/sympy">Source code</a></br>
-<a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a></br>
-<a href="http://code.google.com/p/sympy/">Google Code Page</a></br>
-<a href="http://github.com/sympy/sympy/wiki">Wiki</a></br>
-<a href="http://live.sympy.org/">Try SymPy online now</a></br>
-</p>
+    <p>
+      <a href="http://docs.sympy.org/">Documentation</a><br />
+      <a href="http://code.google.com/p/sympy/downloads/list">Downloads (source tarballs)</a><br />
+      <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (packages for distributions)</a><br />
+      <a href="http://github.com/sympy/sympy">Source code</a><br />
+      <a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a><br />
+      <a href="http://code.google.com/p/sympy/">Google Code Page</a><br />
+      <a href="http://github.com/sympy/sympy/wiki">Wiki</a><br />
+      <a href="http://live.sympy.org/">Try SymPy online now</a><br />
+    </p>
   </div>
 </div>
 

--- a/dev/templates/index.html
+++ b/dev/templates/index.html
@@ -85,16 +85,16 @@ available.
 <div class="block">
   <h3>Quick Links</h3>
   <div class="content">
-<p>
-<a href="http://docs.sympy.org/">Documentation</a></br>
-<a href="http://code.google.com/p/sympy/downloads/list">Downloads (source tarballs)</a></br>
-<a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (packages for distributions)</a></br>
-<a href="http://github.com/sympy/sympy">Source code</a></br>
-<a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a></br>
-<a href="http://code.google.com/p/sympy/">Google Code Page</a></br>
-<a href="http://github.com/sympy/sympy/wiki">Wiki</a></br>
-<a href="http://live.sympy.org/">Try SymPy online now</a></br>
-</p>
+    <p>
+      <a href="http://docs.sympy.org/">Documentation</a><br />
+      <a href="http://code.google.com/p/sympy/downloads/list">Downloads (source tarballs)</a><br />
+      <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (packages for distributions)</a><br />
+      <a href="http://github.com/sympy/sympy">Source code</a><br />
+      <a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a><br />
+      <a href="http://code.google.com/p/sympy/">Google Code Page</a><br />
+      <a href="http://github.com/sympy/sympy/wiki">Wiki</a><br />
+      <a href="http://live.sympy.org/">Try SymPy online now</a><br />
+    </p>
   </div>
 </div>
 


### PR DESCRIPTION
As proposed on the mailing list, quicklinks are now seperated by a newline.

The bug was caused by a typo: </br> instead of the correct <br />.
