### PR TITLE
Updateted 'development.html' page.

### DIFF
--- a/development.html
+++ b/development.html
@@ -71,10 +71,10 @@ We'll review it and push it in.
 
 <p>
 If you need help with git, github, pull requests, patches, coding, SymPy or
-anything related, just send us an email into the mailinglist
-or ask on IRC (our channel is #sympy in freenode), we'll help.
-Also, you can read our
-<a href="https://github.com/sympy/sympy/wiki/Development-workflow">instruction
+anything related, just send us an email to the mailinglist
+or ask on IRC (our channel is <a href="irc://irc.freenode.net/sympy">#sympy at freenode</a>), we'll help.
+Also, you can read our instructions
+<a href="https://github.com/sympy/sympy/wiki/Development-workflow">
 how to prepare patches</a> using git and github.
 </p>
 

--- a/templates/development.html
+++ b/templates/development.html
@@ -43,10 +43,10 @@ We'll review it and push it in.
 
 <p>
 If you need help with git, github, pull requests, patches, coding, SymPy or
-anything related, just send us an email into the mailinglist
-or ask on IRC (our channel is #sympy in freenode), we'll help.
-Also, you can read our
-<a href="https://github.com/sympy/sympy/wiki/Development-workflow">instruction
+anything related, just send us an email to the mailinglist
+or ask on IRC (our channel is <a href="irc://irc.freenode.net/sympy">#sympy at freenode</a>), we'll help.
+Also, you can read our instructions
+<a href="https://github.com/sympy/sympy/wiki/Development-workflow">
 how to prepare patches</a> using git and github.
 </p>
 


### PR DESCRIPTION
To point to github wiki page `Development-workflow`, instead of
the old tutorial.

Firstly 'templates/development.html' was updated, then
'development.html' was generated.
