### PR TITLE
Update links for the next release

### DIFF
--- a/cs/download.html
+++ b/cs/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Zdrojový kód (jednotlivá vydání)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Downloads</a>
-    (na stránkách Google Code)
-  </p>
-</div>
-
-<h2 class="title">Balíčky pro distribuce</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads</a>
+    <a href="https://github.com/sympy/sympy/releases">Downloads</a>
     (na stránkách Google Code)
   </p>
 </div>

--- a/cs/index.html
+++ b/cs/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Jednotlivá vydání: <a href="http://code.google.com/p/sympy/downloads/list">Google Code downloads</a><br/>
-                  Nejnovější git verze: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Dokumentace</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Stáhnout (zdrojový kód tarballs)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Stáhnout (balíčky pro distribuce)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Stáhnout (zdrojový kód tarballs)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Mailing list</a></li>
                       <li><a href="http://github.com/sympy/sympy">Zdrojový kód</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Sledování problémů</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Google Code page</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Wiki</a></li>
                       <li><a href="http://live.sympy.org/">Zkuste SymPy online</a></li>
                       <li><a href="http://sympy.blogspot.com/">Oficiální SymPy blog</a></li>

--- a/de/download.html
+++ b/de/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Source Tarballs (Releases)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Downloads</a>
-    (at Google Code page)
-  </p>
-</div>
-
-<h2 class="title">Packages for Distributions</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads</a>
+    <a href="https://github.com/sympy/sympy/releases">Downloads</a>
     (at Google Code page)
   </p>
 </div>

--- a/de/index.html
+++ b/de/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Releases: <a href="http://code.google.com/p/sympy/downloads/list">Google Code downloads</a><br/>
-                  Latest git version: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Dokumentation</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Downloads (source tarballs)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (packages for distributions)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Downloads (source tarballs)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Mailing list</a></li>
                       <li><a href="http://github.com/sympy/sympy">Source code</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Google Code page</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Wiki</a></li>
                       <li><a href="http://live.sympy.org/">Try SymPy online now</a></li>
                       <li><a href="http://sympy.blogspot.com/">Official SymPy blog</a></li>

--- a/en/download.html
+++ b/en/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Source Tarballs (Releases)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Downloads</a>
-    (at Google Code page)
-  </p>
-</div>
-
-<h2 class="title">Packages for Distributions</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads</a>
+    <a href="https://github.com/sympy/sympy/releases">Downloads</a>
     (at Google Code page)
   </p>
 </div>

--- a/en/index.html
+++ b/en/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Releases: <a href="http://code.google.com/p/sympy/downloads/list">Google Code downloads</a><br/>
-                  Latest git version: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Documentation</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Downloads (source tarballs)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (packages for distributions)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Downloads (source tarballs)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Mailing list</a></li>
                       <li><a href="http://github.com/sympy/sympy">Source code</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Google Code page</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Wiki</a></li>
                       <li><a href="http://live.sympy.org/">Try SymPy online now</a></li>
                       <li><a href="http://sympy.blogspot.com/">Official SymPy blog</a></li>

--- a/es/download.html
+++ b/es/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Fuentes Tar (Lanzamientos)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Descargas</a>
-    (en la página de Google Code)
-  </p>
-</div>
-
-<h2 class="title">Paquetes para Distribución</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Descargas</a>
+    <a href="https://github.com/sympy/sympy/releases">Descargas</a>
     (en la página de Google Code)
   </p>
 </div>

--- a/es/index.html
+++ b/es/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Lanzamientos: <a href="http://code.google.com/p/sympy/downloads/list">Descargas en Google Code</a><br/>
-                  Última versión git: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Documentación</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Descargas (fuentes tar)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Descargas (paquetes para distribución)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Descargas (fuentes tar)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Lista de correos</a></li>
                       <li><a href="http://github.com/sympy/sympy">Código fuente</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Seguimiento de errores</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Página de Google Code</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Wiki</a></li>
                       <li><a href="http://live.sympy.org/">Prueba SymPy online ahora</a></li>
                       <li><a href="http://sympy.blogspot.com/">Blog Oficial de SymPy</a></li>

--- a/fr/download.html
+++ b/fr/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Tarballs des sources (Sorties)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Téléchargements</a>
-    (depuis la page Google Code)
-  </p>
-</div>
-
-<h2 class="title">Paquets pour les Distributions</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Téléchargements</a>
+    <a href="https://github.com/sympy/sympy/releases">Téléchargements</a>
     (depuis la page Google Code)
   </p>
 </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Sorties: <a href="http://code.google.com/p/sympy/downloads/list">Téléchargements Google Code</a><br/>
-                  Dernière version git: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Documentation</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Téléchargements (tarballs des sources)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Téléchargements (paquets pour les distributions)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Téléchargements (tarballs des sources)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Mailing list</a></li>
                       <li><a href="http://github.com/sympy/sympy">Code source</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Suivi des problèmes</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Google Code page</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Wiki</a></li>
                       <li><a href="http://live.sympy.org/">Essayez dès maintenant SymPy en ligne</a></li>
                       <li><a href="http://sympy.blogspot.com/">Blog officiel de SymPy</a></li>

--- a/pt/download.html
+++ b/pt/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Arquivo com as fontes (Lançamentos)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Downloads</a>
-    (na página do Google Code)
-  </p>
-</div>
-
-<h2 class="title">Pacotes para Distribuições</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads</a>
+    <a href="https://github.com/sympy/sympy/releases">Downloads</a>
     (na página do Google Code)
   </p>
 </div>

--- a/pt/index.html
+++ b/pt/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Lançamentos: <a href="http://code.google.com/p/sympy/downloads/list">Downloads no Google Code</a><br/>
-                  Última versão no git: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Documentação</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Downloads (código em tarballs)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Downloads (pacotes de distribuições)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Downloads (código em tarballs)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Lista de emails</a></li>
                       <li><a href="http://github.com/sympy/sympy">Código fonte</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Lista de bugs</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">página do Google Code</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Wiki</a></li>
                       <li><a href="http://live.sympy.org/">Experimente SymPy online agora</a></li>
                       <li><a href="http://sympy.blogspot.com/">Blog oficial do SymPy</a></li>

--- a/ru/download.html
+++ b/ru/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Архивы с исходными кодами (релизы)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">Загрузки</a>
-    (на Google Code)
-  </p>
-</div>
-
-<h2 class="title">Пакеты для дистрибутивов</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Загрузки</a>
+    <a href="https://github.com/sympy/sympy/releases">Загрузки</a>
     (на Google Code)
   </p>
 </div>

--- a/ru/index.html
+++ b/ru/index.html
@@ -232,8 +232,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  Релизы: <a href="http://code.google.com/p/sympy/downloads/list">Загрузки на Google Code</a><br/>
-                  Последняя git версия: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -250,12 +250,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">Документация</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">Загрузки (архивы с исходными текстами)</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">Загрузки (пакеты для дистрибутивов)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">Загрузки (архивы с исходными текстами)</a></li>
                       <li><a href="http://groups.google.com/group/sympy">Mailing list</a></li>
                       <li><a href="http://github.com/sympy/sympy">Исходный код</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Система отслеживания ошибок</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Google Code page</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">Вики</a></li>
                       <li><a href="http://live.sympy.org/">Попробуйте поработать с SymPy онлайн</a></li>
                       <li><a href="http://sympy.blogspot.com/">Официальный блог SymPy</a></li>

--- a/templates/download.html
+++ b/templates/download.html
@@ -8,15 +8,7 @@
 <h2 class="title">{% trans %}Source Tarballs (Releases){% endtrans %}</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">{% trans %}Downloads{% endtrans %}</a>
-    ({% trans %}at Google Code page{% endtrans %})
-  </p>
-</div>
-
-<h2 class="title">{% trans %}Packages for Distributions{% endtrans %}</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">{% trans %}Downloads{% endtrans %}</a>
+    <a href="https://github.com/sympy/sympy/releases">{% trans %}Downloads{% endtrans %}</a>
     ({% trans %}at Google Code page{% endtrans %})
   </p>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -178,8 +178,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  {% trans %}Releases{% endtrans %}: <a href="http://code.google.com/p/sympy/downloads/list">{% trans %}Google Code downloads{% endtrans %}</a><br/>
-                  {% trans %}Latest git version{% endtrans %}: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">{% trans %}Latest Version{% endtrans %}</a><br/>
+                  <a href="http://github.com/sympy/sympy">{% trans %}Development Version{% endtrans %}</a>
                 </p>
               </div>
             </div>
@@ -196,12 +196,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">{% trans %}Documentation{% endtrans %}</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">{% trans %}Downloads (source tarballs){% endtrans %}</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">{% trans %}Downloads (packages for distributions){% endtrans %}</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">{% trans %}Downloads (source tarballs){% endtrans %}</a></li>
                       <li><a href="http://groups.google.com/group/sympy">{% trans %}Mailing list{% endtrans %}</a></li>
                       <li><a href="http://github.com/sympy/sympy">{% trans %}Source code{% endtrans %}</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">{% trans %}Issues tracker{% endtrans %}</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">{% trans %}Google Code page{% endtrans %}</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">{% trans %}Wiki{% endtrans %}</a></li>
                       <li><a href="http://live.sympy.org/">{% trans %}Try SymPy online now{% endtrans %}</a></li>
                       <li><a href="http://sympy.blogspot.com/">{% trans %}Official SymPy blog{% endtrans %}</a></li>

--- a/zh/download.html
+++ b/zh/download.html
@@ -41,15 +41,7 @@
 <h2 class="title">Source Tarballs (Releases)</h2>
 <div class="inner">
   <p class="first">
-    <a href="http://code.google.com/p/sympy/downloads/list">下载</a>
-    (在google code页面)
-  </p>
-</div>
-
-<h2 class="title">发布的软件包</h2>
-<div class="inner">
-  <p class="first">
-    <a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">下载</a>
+    <a href="https://github.com/sympy/sympy/releases">下载</a>
     (在google code页面)
   </p>
 </div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -225,8 +225,8 @@
             <div class="content">
               <div id="thetext">
                 <p>
-                  发布版本: <a href="http://code.google.com/p/sympy/downloads/list">Google Code 下载</a><br/>
-                  最新 git 版本: <a href="http://github.com/sympy/sympy">github.com/sympy/sympy</a>
+                  <a href="https://github.com/sympy/sympy/releases">Latest Version</a><br/>
+                  <a href="http://github.com/sympy/sympy">Development Version</a>
                 </p>
               </div>
             </div>
@@ -243,12 +243,10 @@
                   <ul>
                     <font size="3">
                       <li><a href="http://docs.sympy.org/">文档</a></li>
-                      <li><a href="http://code.google.com/p/sympy/downloads/list">下载(源码包）</a></li>
-                      <li><a href="http://code.google.com/p/sympy/wiki/DownloadInstallation?tm=2">下载(发行软件包)</a></li>
+                      <li><a href="https://github.com/sympy/sympy/releases">下载(源码包）</a></li>
                       <li><a href="http://groups.google.com/group/sympy">邮件列表</a></li>
                       <li><a href="http://github.com/sympy/sympy">源码</a></li>
                       <li><a href="http://code.google.com/p/sympy/issues/list">Issues tracker</a></li>
-                      <li><a href="http://code.google.com/p/sympy/">Google Code 页面</a></li>
                       <li><a href="http://github.com/sympy/sympy/wiki">维基</a></li>
                       <li><a href="http://live.sympy.org/">立即在线尝试SymPy</a></li>
                       <li><a href="http://sympy.blogspot.com/">SymPy官方博客</a></li>


### PR DESCRIPTION
I removed all references to Google Code (except for the issue tracker), and 
also links to packages on other systems, which was an out-dated page.
