### PR TITLE
Update the copyright year: 2016 -> 2018

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -109,7 +109,7 @@
       </aside>
     </section>
     <footer class="row">
-      <p>Copyright &copy; 2016 SymPy Development Team. </p>
+      <p>Copyright &copy; 2018 SymPy Development Team. </p>
       <p>
         {% trans url='https://github.com/sympy/sympy.github.com' %}This page is open source. Fork <a href="{{ url }}">the project on GitHub</a> to edit it.{% endtrans %}
       </p>


### PR DESCRIPTION
This year appears in the footer of http://www.sympy.org/