### PR TITLE
We no longer need to install doctr from git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
 
 script:
   - set -e
-  - pip install jinja2 babel
-  - pip install git+https://github.com/drdoctr/doctr@exclude
+  - pip install jinja2 babel doctr
   - ./generate
   - doctr deploy --branch-whitelist sources --exclude static --built-docs . .


### PR DESCRIPTION
I just released doctr 1.7.2 which has the necessary fixes for it to work with this repo. 