### PR TITLE
Add Stack Overflow to the list of help channels

### DIFF
--- a/templates/support.html
+++ b/templates/support.html
@@ -14,9 +14,10 @@
     <ul>
       <li>{% trans %} SymPy <a href="http://docs.sympy.org">Documentation</a>{% endtrans %}</li>
       <li>{% trans %} Main <a href="https://groups.google.com/forum/#!forum/sympy">mailinglist</a> {% endtrans %}</li>
-      <li>{% trans %}<a href="https://github.com/sympy/sympy/issues/">Issues tracker</a>.{% endtrans %}
+      <li>{% trans %} <a href="https://github.com/sympy/sympy/issues/">Issue tracker</a>.{% endtrans %}
       </li>
       <li>{% trans %}Gitter channel: <a href="https://gitter.im/sympy/sympy">#sympy at Gitter</a>.{% endtrans %}</li>
+      <li>{% trans %}Stack Overflow: <a href="https://stackoverflow.com/questions/tagged/sympy">[sympy] tag</a>.{% endtrans %}</li>
     </ul>
   </p>
 </div>


### PR DESCRIPTION
Add Stack Overflow to the list of ways to get help.

There are certainly more support questions asked on SO than on the mailing list.