### PR TITLE
Removed the link to sympy.blogspot.com

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -72,7 +72,6 @@
               <li><a href="https://github.com/sympy/sympy/wiki">{% trans %}Wiki{% endtrans %}</a></li>
               <li><a href="https://github.com/sympy/sympy/wiki/introduction-to-contributing">{% trans %}Introduction to contributing{% endtrans %}</a></li>
               <li><a href="http://live.sympy.org/">{% trans %}Try SymPy online now{% endtrans %}</a></li>
-              <li><a href="http://sympy.blogspot.com/">{% trans %}Official SymPy blog{% endtrans %}</a></li>
               <li><a href="http://planet.sympy.org/">{% trans %}Planet SymPy{% endtrans %}</a></li>
               <li><a href="https://gitter.im/sympy/sympy">{% trans %}Chat (Gitter){% endtrans %}</a></li>
               <li><a href="http://colabti.org/irclogger/irclogger_logs/sympy">{% trans %}IRC channel logs{% endtrans %}</a></li>


### PR DESCRIPTION
Fixes #107 

The link to abandoned blog sympy.blogspot.com is removed from Quick Links sidebar on sympy.org