### PR TITLE
link to unyt docs instead of yt.units docs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -56,7 +56,7 @@ project here as well.{% endtrans %}</p>
 <li><strong><a href="https://github.com/brombo/galgebra">{% trans %}galgebra{% endtrans %}</a></strong>: {% trans %} Geometric algebra (previously sympy.galgebra). {% endtrans%}</li>
 <li><strong><a href="http://yt-project.org/">{% trans %}yt{% endtrans
       %}</a></strong>: {% trans %} Python package for analyzing and visualizing
-  volumetric data (<a href="http://yt-project.org/doc/analyzing/units/index.html">yt.units</a> uses SymPy). {% endtrans%}</li>
+  volumetric data (<a href="https://unyt.readthedocs.io">unyt</a>, the yt unit system, uses SymPy). {% endtrans%}</li>
 <li><strong><a href="http://sfepy.org/">{% trans %}SfePy{% endtrans %}</a></strong>: {% trans %} Simple finite elements in Python. {% endtrans%}</li>
 <li><strong><a href="http://quameon.sourceforge.net/">{% trans %}Quameon{% endtrans %}</a></strong>: {% trans %} Quantum Monte Carlo in Python. {% endtrans%}</li>
 <li><strong><a href="http://lcapy.elec.canterbury.ac.nz/">{% trans %}Lcapy{% endtrans %}</a></strong>: {% trans %} Experimental Python package for teaching linear circuit analysis. {% endtrans%}</li>


### PR DESCRIPTION
We've recently split off yt.units into it's own package, unyt: github.com/yt-project/unyt. This updates the index page to link to mention unyt and link to the unyt docs instead of the yt.units docs.