### PR TITLE
Add Spyder to the list of projects using SymPy

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -70,6 +70,7 @@ project here as well.{% endtrans %}</p>
 <li><strong><a href="https://github.com/bjodah/pyodesys">{% trans %}pyodesys{% endtrans %}</a></strong>: {% trans %} Straightforward numerical integration of ODE systems from Python. {% endtrans%}</li>
 <li><strong><a href="https://github.com/bjodah/pyneqsys">{% trans %}pyneqsys{% endtrans %}</a></strong>: {% trans %} Solve symbolically defined systems of non-linear equations numerically. {% endtrans%}</li>
 <li><strong><a href="https://github.com/bjodah/chempy">{% trans %}ChemPy{% endtrans %}</a></strong>: {% trans %} A package useful for chemistry written in Python. {% endtrans%}</li>
+<li><strong><a href="https://www.spyder-ide.org/">{% trans %}Spyder{% endtrans %}</a></strong>: {% trans %} The Scientific Python Development Environment, a Python equivalent to Rstudio or MATLAB; full SymPy support can be enabled in Spyder's <a href="https://docs.spyder-ide.org/ipythonconsole.html">IPython Consoles</a>. {% endtrans%}</li>
 </ul>
 
 </div>


### PR DESCRIPTION
Just as it says on the tin, adds the [Spyder IDE](https://www.spyder-ide.org/) to the [list of projects that use SymPy](http://www.sympy.org/en/index.html). Spyder offers the option to enable full SymPy support in its IPython Consoles, and (in Spyder 4) offers a dedicated option to open new SymPy-specific consoles alongside standard IPython Consoles and specialized Cython and PyLab ones. I presumed that just hacking the raw HTML template is still the current way to add a new project, rather than something involving a modern static site generator or the like, but please let me know if that or something else is in error and I'll swiftly correct it. Thanks!