### PR TITLE
Replace Quameon with QMCPACK

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -97,9 +97,9 @@ project here as well.{% endtrans %}</p>
       {% trans %} Straightforward numerical integration of ODE systems from
       Python. {% endtrans%}
     </li>
-    <li><strong><a href="http://quameon.sourceforge.net/">
-      {% trans %}Quameon{% endtrans %}</a></strong>:
-      {% trans %} Quantum Monte Carlo in Python. {% endtrans%}
+    <li><strong><a href="http://qmcpack.org/">
+      {% trans %}QMCPACK{% endtrans %}</a></strong>:
+      {% trans %} Quantum Monte Carlo in C++. Sympy is used to generate reference values for unit tests and some code generation.{% endtrans%}
     </li>
     <li><strong><a href="https://digitalcommons.calpoly.edu/cgi/viewcontent.cgi?article=1072&context=physsp/">
       {% trans %}Quantum Programming in Python{% endtrans %}</a></strong>:


### PR DESCRIPTION
Quameon is a long dormant project and should be removed from the list.

QMCPACK is primarily written in C++.  It uses Sympy for some code generation and creation of reference values for unit tests (I am a developer on QMCPACK, and have been the primary push for the use of Sympy in it).  I don't know if it is notable enough or uses enough Sympy to be on the list.   I would also be fine with simply removing Quameon.