### PR TITLE
Correct dead link to galgebra

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@ project here as well.{% endtrans %}</p>
       {% trans %} A Python package for symbolic and numerical
       General Relativity. {% endtrans%}
     </li>
-    <li><strong><a href="https://github.com/brombo/galgebra">
+    <li><strong><a href="https://github.com/pygae/galgebra">
       {% trans %}galgebra{% endtrans %}</a></strong>:
       {% trans %} Geometric algebra (previously sympy.galgebra). {% endtrans%}
     </li>


### PR DESCRIPTION
https://github.com/pygae/galgebra is the new home