### PR TITLE
Correct the translation of geometric algebra

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1125,7 +1125,7 @@ msgstr "galgebra"
 
 #: templates/index.html:60
 msgid " Geometric algebra (previously sympy.galgebra). "
-msgstr " Geometría algebraica (anteriormente sympy.galgebra). "
+msgstr " Álgebra Geométrica (anteriormente sympy.galgebra). "
 
 #: templates/index.html:63
 msgid "LaTeX Expression project"


### PR DESCRIPTION
This previously said "algebraic geometry".

cc @utensil, who I think has fallen for this type of mistake before.