### PR TITLE
Update link to galgebra

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,7 @@ project here as well.{% endtrans %}</p>
       {% trans %} A Python package for symbolic and numerical
       General Relativity. {% endtrans%}
     </li>
-    <li><strong><a href="https://github.com/brombo/galgebra">
+    <li><strong><a href="https://galgebra.readthedocs.io/en/latest/">
       {% trans %}galgebra{% endtrans %}</a></strong>:
       {% trans %} Geometric algebra (previously sympy.galgebra). {% endtrans%}
     </li>


### PR DESCRIPTION
Updated link: https://galgebra.readthedocs.io/en/latest/