### PR TITLE
Add NRPyLaTeX to Projects using SymPy

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -76,6 +76,10 @@ project here as well.{% endtrans %}</p>
       {% trans %} Experimental Python package for teaching linear circuit
       analysis. {% endtrans%}
     </li>
+    <li><strong><a href="https://github.com/zachetienne/nrpylatex">
+      {% trans %}NRPyLaTeX{% endtrans %}</a></strong>:
+      {% trans %} A LaTeX Interface to SymPy for General Relativity. {% endtrans%}
+    </li>
     <li><strong><a href="https://github.com/cbm755/octsympy">
       {% trans %}OctSymPy{% endtrans %}</a></strong>:
       {% trans %} A Symbolic Package for Octave using SymPy. {% endtrans %}


### PR DESCRIPTION
Mailing List [https://groups.google.com/g/sympy/c/iT7Ri1fnW3A](https://groups.google.com/g/sympy/c/iT7Ri1fnW3A)
GitHub [https://github.com/zachetienne/nrpylatex](https://github.com/zachetienne/nrpylatex)

We recently published the Python package NRPyLaTeX on PyPI ([nrpylatex · PyPI](https://pypi.org/project/nrpylatex/)), and are currently writing a publication for [Classical and Quantum Gravity](https://iopscience.iop.org/journal/0264-9381) (CQG). We developed NRPyLaTeX (originally a companion package to [NRPy+](http://astro.phys.wvu.edu/bhathome/nrpy.html)) to provide a LaTeX interface to SymPy for General Relativity, including support for Einstein notation. We are proposing that NRPyLaTeX be added to the "Projects using SymPy" section of the SymPy homepage.