### PR TITLE
Use JupyterLite and Pyodide for the online shell

### DIFF
--- a/generate
+++ b/generate
@@ -30,6 +30,7 @@ templates = [
     "development.html",
     "roadmap.html",
     "donate.html",
+    "shell.html",
     ]
 
 # Sorted alphabetically:

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
           <li class="{{ development_active }}"><a href="development.html">{% trans %}Development{% endtrans %}</a></li>
           <li class="{{ roadmap_active }}"><a href="roadmap.html">{% trans %}Roadmap{% endtrans %}</a></li>
           <li class="{{ donate_active }}"><a href="donate.html">{% trans %}Donate{% endtrans %}</a></li>
-          <li><a href="https://live.sympy.org/">{% trans %}Online Shell{% endtrans %} <i class="icon-external-link-sign"></i></a></li>
+          <li class="{{ shell_active }}""><a href="shell.html">{% trans %}Online Shell{% endtrans %}</a></li>
         </ul>
         {% endblock %}
       </nav>

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}SymPy Live{% endblock %}
+
+{% block content %}
+<h1>SymPy Live</h1>
+<iframe
+    src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
+    width="100%"
+    height="500px"
+>
+</iframe>
+
+<div id="example" class="sidebar_card">
+    <a id="#example">
+        <div class="clickable_top">
+            <h3>Example session</h3>
+        </div>
+    </a>
+    <div class="content">
+        <pre class="executable">
+&gt;&gt;&gt; expr = (x + y)**5
+&gt;&gt;&gt; expand(expr)
+$$ x^5 + 5 x^4 y + 10 x^3 y^2 + 10 x^2 y^3 + 5 x y^4 + y^5 $$
+&gt;&gt;&gt; sin(x).series(x, 0, 5)
+$$ x - \frac16 x^3 + O(x^5) $$</pre>
+
+        More information can be found at <a href="https://docs.sympy.org/">https://docs.sympy.org/</a>.
+
+
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -3,9 +3,19 @@
 {% block title %}SymPy Live{% endblock %}
 
 {% block content %}
+
+{% set host = "https://jupyterlite.github.io" %}
+{% set path = "demo/repl/" %}
+{% set query = "?toolbar=1&kernel=python" %}
+{% set code1 = "from sympy import *" %}
+{% set code2 = "x, y, z, t = symbols('x y z t')" %}
+{% set code3 = "k, m, n = symbols('k m n', integer=True)" %}
+{% set code4 = "f, g, h = symbols('f g h', cls=Function)" %}
+{% set initcode = "\n".join([code1, code2, code3, code4]) %}
+
 <h1>SymPy Live</h1>
 <iframe
-    src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
+    src="{{ host }}/{{ path }}{{ query }}&code={{ initcode|urlencode }}"
     width="100%"
     height="500px"
 >
@@ -21,9 +31,9 @@
         <pre class="executable">
 &gt;&gt;&gt; expr = (x + y)**5
 &gt;&gt;&gt; expand(expr)
-$$ x^5 + 5 x^4 y + 10 x^3 y^2 + 10 x^2 y^3 + 5 x y^4 + y^5 $$
-&gt;&gt;&gt; sin(x).series(x, 0, 5)
-$$ x - \frac16 x^3 + O(x^5) $$</pre>
+x**5 + 5*x**4*y + 10*x**3*y**2 + 10*x**2*y**3 + 5*x*y**4 + y**5
+&gt;&gt;&gt; sin(x).series(x, 0, 7)
+x - x**3/6 + x**5/120 + O(x**7)</pre>
 
         More information can be found at <a href="https://docs.sympy.org/">https://docs.sympy.org/</a>.
 


### PR DESCRIPTION
This is an alternative to https://github.com/sympy/sympy-live/pull/198

Fixes https://github.com/sympy/sympy-live/issues/83
Closes https://github.com/sympy/sympy-live/pull/198

Copying the PR description from https://github.com/sympy/sympy-live/pull/198 to here for reference:

JupyterLite is a JupyterLab distribution that runs entirely in the web browser, backed by in-browser language kernels including the WebAssembly powered [Pyodide](https://pyodide.org) kernel.

The embeddable code console is currently deployed as a static website on Vercel, and the source code is currently living in the following repository: https://github.com/jtpio/replite

It supports rich rendering of outputs just like in Jupyter Notebook and JupyterLab, for example:

![image](https://user-images.githubusercontent.com/591645/154267806-f28b2576-2235-42a8-b159-99e3395bbb52.png)


**TODO**

- [x] Add a new shell template to the repo
- [x] Embed the JupyterLite REPL app in an `iframe`: https://jupyterlite.readthedocs.io/en/latest/applications/repl.html
- [x] Execute starter code by default:

```
>>> from __future__ import division
>>> from sympy import *
>>> x, y, z, t = symbols('x y z t')
>>> k, m, n = symbols('k m n', integer=True)
>>> f, g, h = symbols('f g h', cls=Function)
```

This also means the https://github.com/sympy/sympy-live repo could then be archived after this PR is merged, and the Google App Engine deployment be deleted.

