### PR TITLE
make sidebar an overwritable block

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -48,6 +48,7 @@
         </div>
         <div id="spacer" class="col span_1 clr small_span_0">&nbsp;</div>
         <aside id="sidebar" class="col span_4 clr small_span_2">
+          {% block sidebar %}
           <div id="search-gamma" class="sidebar_card">
             <h3>{% trans %} Compute with Gamma {% endtrans %}</h3>
             <form method="get" action="https://www.sympygamma.com/input/" target="_blank">
@@ -103,7 +104,8 @@
                 js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document,
                 'script', 'twitter-wjs');</script>
           </div>
-          {% block sidebar %}
+          {% endblock %}
+          {% block sidebarextra %}
           {% endblock %}
       </aside>
     </section>

--- a/templates/development.html
+++ b/templates/development.html
@@ -77,7 +77,7 @@
 {% endblock %}
 
 
-{% block sidebar %}
+{% block sidebarextra %}
 
 <div id="about" class="sidebar_card">
     <h3>{% trans %}Git Repository{% endtrans %}</h3>

--- a/templates/index.html
+++ b/templates/index.html
@@ -146,7 +146,7 @@ project here as well.{% endtrans %}</p>
 {% endblock %}
 
 
-{% block sidebar %}
+{% block sidebarextra %}
 <div class="sidebar_card">
     <h3>{% trans %}News{% endtrans %}</h3>
     <p>

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -120,7 +120,7 @@
 {% endblock %}
 
 
-{% block sidebar %}
+{% block sidebarextra %}
 
 <div id="about" class="sidebar_card">
     <h3>{% trans %}Git Repository{% endtrans %}</h3>


### PR DESCRIPTION
Currently the contents of the `sidebar` div are included in all pages derived from `base.html`.

In order to support work on https://github.com/sympy/sympy.github.com/pull/169 , we would like to make the sidebar menu overwitable.

This PR adds a new template block called `sidebar` around the "default" sidebar content.

The current block `sidebar` has been renamed to `sidebarextra` and relevant child tempaltes have been updated. (used to add extra sidebar content only on certain pages)


