### PR TITLE
JupyterLite-based shell at https://www.sympy.org/en/shell.html

### DIFF
--- a/generate
+++ b/generate
@@ -30,6 +30,7 @@ templates = [
     "development.html",
     "roadmap.html",
     "donate.html",
+    "shell.html",
     ]
 
 # Sorted alphabetically:

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
           <li class="{{ development_active }}"><a href="development.html">{% trans %}Development{% endtrans %}</a></li>
           <li class="{{ roadmap_active }}"><a href="roadmap.html">{% trans %}Roadmap{% endtrans %}</a></li>
           <li class="{{ donate_active }}"><a href="donate.html">{% trans %}Donate{% endtrans %}</a></li>
-          <li><a href="https://live.sympy.org/">{% trans %}Online Shell{% endtrans %} <i class="icon-external-link-sign"></i></a></li>
+          <li class="{{ shell_active }}""><a href="shell.html">{% trans %}Online Shell{% endtrans %}</a></li>
         </ul>
         {% endblock %}
       </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
     <link rel="icon" href="/static/SymPy-Favicon.ico" />
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
     <script type="text/javascript" src="/static/javascript/main.js"></script>
+    {% block extrahead %}{% endblock %}
   </head>
   <body>
     <div class="container">

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}SymPy Live{% endblock %}
+
+{% block content %}
+<h1>SymPy Live</h1>
+<iframe
+    src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
+    width="100%"
+    height="500px"
+>
+</iframe>
+
+<div id="example" class="sidebar_card">
+    <a id="#example">
+        <div class="clickable_top">
+            <h3>Example session</h3>
+        </div>
+    </a>
+    <div class="content">
+        <pre class="executable">
+&gt;&gt;&gt; expr = (x + y)**5
+&gt;&gt;&gt; expand(expr)
+$$ x^5 + 5 x^4 y + 10 x^3 y^2 + 10 x^2 y^3 + 5 x y^4 + y^5 $$
+&gt;&gt;&gt; sin(x).series(x, 0, 5)
+$$ x - \frac16 x^3 + O(x^5) $$</pre>
+
+        More information can be found at <a href="https://docs.sympy.org/">https://docs.sympy.org/</a>.
+
+
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% set loading_overlay_duration = 18000 %}
-{% set host = "https://jupyterlite.github.io" %}
-{% set path = "demo/repl/" %}
+{% set host = "https://sympy.github.io" %}
+{% set path = "live/repl/" %}
 {% set query = "?toolbar=1&kernel=python" %}
 {% set code1 = "from sympy import *" %}
 {% set code2 = "init_printing()" %}

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -164,7 +164,7 @@
         <code>[2]: expr = (x + y)**3</code>
       </p>
       <p>
-        <code>[3]: expr = (x + y)**3</code><br>
+        <code>[3]: expand(expr)</code><br>
         <code>[3]: </code>\(x^{3} + 3 x^{2} y + 3 x y^{2} + y^{3}\)<br>
       </p>
       <p>

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,34 +1,208 @@
 {% extends "base.html" %}
 
+{% set loading_overlay_duration = 18000 %}
+{% set host = "https://jupyterlite.github.io" %}
+{% set path = "demo/repl/" %}
+{% set query = "?toolbar=1&kernel=python" %}
+{% set code1 = "from sympy import *" %}
+{% set code2 = "init_printing()" %}
+{% set code3 = "x, y, z, t = symbols('x y z t')" %}
+{% set code4 = "k, m, n = symbols('k m n', integer=True)" %}
+{% set code5 = "f, g, h = symbols('f g h', cls=Function)" %}
+{% set initcode = "\n".join([code1, code2, code3, code4, code5]) %}
+
+
 {% block title %}SymPy Live{% endblock %}
 
-{% block content %}
-<h1>SymPy Live</h1>
-<iframe
-    src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=from%20sympy%20import%20*&code=x,%20y,%20z,%20t%20=%20symbols(%27x%20y%20z%20t%27)&code=k,%20m,%20n%20=%20symbols(%27k%20m%20n%27,%20integer=True)&code=f,%20g,%20h%20=%20symbols(%27f%20g%20h%27,%20cls=Function)"
-    width="100%"
-    height="500px"
->
-</iframe>
-
-<div id="example" class="sidebar_card">
-    <a id="#example">
-        <div class="clickable_top">
-            <h3>Example session</h3>
-        </div>
-    </a>
-    <div class="content">
-        <pre class="executable">
-&gt;&gt;&gt; expr = (x + y)**5
-&gt;&gt;&gt; expand(expr)
-$$ x^5 + 5 x^4 y + 10 x^3 y^2 + 10 x^2 y^3 + 5 x y^4 + y^5 $$
-&gt;&gt;&gt; sin(x).series(x, 0, 5)
-$$ x - \frac16 x^3 + O(x^5) $$</pre>
-
-        More information can be found at <a href="https://docs.sympy.org/">https://docs.sympy.org/</a>.
 
 
-    </div>
-</div>
+
+
+
+{% block extrahead %}
+
+<!-- loading overlay -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gasparesganga-jquery-loading-overlay@2.1.7/dist/loadingoverlay.min.js"></script>
+<script>
+  $(document).ready(function() {
+    $.LoadingOverlay("show", {
+      text: "SymPy live shell is loading...",
+      textResizeFactor: 0.2
+    });
+    setTimeout(function(){
+      $.LoadingOverlay("hide");
+    }, {{ loading_overlay_duration }});
+  });
+</script>
+
+
+<!-- MathJax 3 -->
+<script>window.MathJax = {"tex": {"inlineMath": [["\\(", "\\)"]], "displayMath": [["\\[", "\\]"]]}, "options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
+<script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
+
+<!-- handler for evaluate commands -->
+<script>
+  function getURLParameter(name) {
+    return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
+  }
+
+  function statementsToCodes(statements) {
+    var statements = statements
+        .replace('\r\n', '\n')
+        .replace('\r', '\n')
+        .split(/#--[^\n]*/);
+    var codes = [];
+    for (const idx in statements) {
+      statement = statements[idx].trim()
+      if (statement) {
+        codes.push(statement);
+      }
+    }
+    return codes;
+  }
+
+  $(document).ready(function() {
+    // default iframe src with SymPy initcode
+    var iframe_src = "{{ host }}/{{ path }}{{ query }}&code={{ initcode|urlencode }}";
+    // check if we have additional statements to evaluate in the query string
+    var statements = getURLParameter('evaluate');
+    if (statements) {
+      codes = statementsToCodes(statements);
+      console.log(codes);
+      for (const idx in codes) {
+        iframe_src += '&code=' + encodeURIComponent(codes[idx]);
+      }
+    }
+    $('#live-iframe').prop("src", iframe_src);
+  });
+</script>
+
+
 {% endblock %}
+
+
+
+
+
+
+
+
+
+
+{% block content %}
+
+
+  <h1>SymPy Live</h1>
+
+  <iframe
+      id="live-iframe"
+      src=""
+      width="100%"
+      height="500px"
+  >
+  </iframe>
+
+  <div id="usage" class="sidebar_card">
+      <h3>Instructions</h3>
+      <div class="content">
+        <p>
+          Press <b>SHIFT</b> + <b>ENTER</b> to run the code.<br>
+          On mobile, use the play button (triangle) in the toolbar to run the code.
+        </p>
+      </div>
+  </div>
+
+
+{% endblock %}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+{% block sidebar %}
+
+<div id="about_shell" class="sidebar_card">
+  <h3>{% trans %}About this page{% endtrans %}</h3>
+  <p>
+    {% trans %}SymPy Live shell allows you to use SymPy in the browser without the need to install anything on your computer.{% endtrans %}
+  </p>
+
+  <p>
+    {% trans %}The following commands are executed by default:{% endtrans %}
+    <pre>
+[1]: from sympy import *
+     x, y, z, t = symbols('x y z t')
+     k, m, n = symbols('k m n', integer=True)
+     f, g, h = symbols('f g h', cls=Function)
+    </pre>
+  </p>
+  <p>
+    {% trans %}SymPy Live shell is powered by{% endtrans %} <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite</a>.
+  </p>
+
+  <p>
+    {% trans %}Note it can take up to 30 seconds before the shell loads and becomes available for using interactively.{% endtrans %}    
+  </p>
+</div>
+
+
+
+<div id="examples" class="sidebar_card">
+    <h3>Example session</h3>
+    <div class="content">
+      <p>
+        <code>[2]: expr = (x + y)**3</code>
+      </p>
+      <p>
+        <code>[3]: expr = (x + y)**3</code><br>
+        <code>[3]: </code>\(x^{3} + 3 x^{2} y + 3 x y^{2} + y^{3}\)<br>
+      </p>
+      <p>
+        <code>[4]: sin(x).series(x, 0, 7)</code><br>
+        <code>[4]: </code>\(x - \frac{x^{3}}{6} + \frac{x^{5}}{120} + O\left(x^{7}\right)\)<br>
+      </p>
+
+      <p>
+        {% trans %}Read the tutorial in the SymPy docs to learn more about SymPy{% endtrans %}: 
+        <a href="https://docs.sympy.org/tutorial/">{% trans %}SymPy Tutorial{% endtrans %}</a>.
+      </p>
+  </div>
+</div>
+
+
+
+<div id="quick_links" class="sidebar_card">
+  <h3>{% trans %}Quick Links{% endtrans %}</h3>
+  <ul>
+    <li><a href="https://docs.sympy.org/tutorial/">{% trans %}SymPy Tutorial{% endtrans %}</a></li>
+    <li><a href="https://docs.sympy.org/">{% trans %}Documentation{% endtrans %}</a></li>
+    <li><a href="https://github.com/sympy/sympy/releases">{% trans %}Downloads (source tarballs){% endtrans %}</a></li>
+    <li><a href="https://groups.google.com/group/sympy">{% trans %}Mailing list{% endtrans %}</a></li>
+    <li><a href="https://github.com/sympy/sympy">{% trans %}Source code{% endtrans %}</a></li>
+    <li><a href="https://github.com/sympy/sympy/issues/">{% trans %}Issues tracker{% endtrans %}</a></li>
+    <li><a href="https://github.com/sympy/sympy/wiki">{% trans %}Wiki{% endtrans %}</a></li>
+    <li><a href="https://github.com/sympy/sympy/wiki/introduction-to-contributing">{% trans %}Introduction to contributing{% endtrans %}</a></li>
+    <li><a href="https://live.sympy.org/">{% trans %}Try SymPy online now{% endtrans %}</a></li>
+    <li><a href="https://planet.sympy.org/">{% trans %}Planet SymPy{% endtrans %}</a></li>
+    <li><a href="https://gitter.im/sympy/sympy">{% trans %}Chat (Gitter){% endtrans %}</a></li>
+    <li><a href="http://colabti.org/irclogger/irclogger_logs/sympy">{% trans %}IRC channel logs{% endtrans %}</a></li>
+  </ul>
+</div>
+
+{% endblock %}
+
+
+
+
+
 

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
-{% set loading_overlay_duration = 3000 %}
-{% set loading_message_duration = 10000 %}
+
 {% set host = "https://sympy.github.io" %}
 {% set path = "live/repl/" %}
 {% set query = "?toolbar=1&kernel=python" %}
@@ -16,29 +15,7 @@
 {% block title %}SymPy Live{% endblock %}
 
 
-
-
-
-
 {% block extrahead %}
-
-<!-- loading overlay and info message -->
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gasparesganga-jquery-loading-overlay@2.1.7/dist/loadingoverlay.min.js"></script>
-<script>
-  $(document).ready(function() {
-    $.LoadingOverlay("show", {
-      text: "Loading SymPy live shell...",
-      textResizeFactor: 0.2
-    });
-    setTimeout(function(){
-      $.LoadingOverlay("hide");
-    }, {{ loading_overlay_duration }});
-    setTimeout(function(){
-      $('#loading_message').hide();
-    }, {{ loading_message_duration }});
-  });
-</script>
-
 
 <!-- MathJax 3 -->
 <script>window.MathJax = {"tex": {"inlineMath": [["\\(", "\\)"]], "displayMath": [["\\[", "\\]"]]}, "options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
@@ -82,29 +59,13 @@
   });
 </script>
 
-
 {% endblock %}
 
 
 
 
 
-
-
-
-
-
 {% block content %}
-
-  <div id="loading_message" class="sidebar_card">
-    <div class="content">
-      <p>
-        {% trans %}Note it can take up to 30 seconds before the shell finishes loading and is ready to run commands.{% endtrans %}    
-      </p>
-    </div>
-  </div>
-
-
 
   <h1>SymPy Live</h1>
 
@@ -122,21 +83,13 @@
         <p>
           {% trans %}Press ENTER to run the code or use the Run button in the toolbar.{% endtrans %}
         </p>
+        <p id="loading_message">
+          {% trans %}Note it can take up to 30 seconds before the shell finishes loading and is ready to run commands.{% endtrans %}    
+        </p>
       </div>
   </div>
 
-
 {% endblock %}
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -164,7 +117,6 @@
 </div>
 
 
-
 <div id="examples" class="sidebar_card">
     <h3>Example session</h3>
     <div class="content">
@@ -188,7 +140,6 @@
 </div>
 
 
-
 <div id="quick_links" class="sidebar_card">
   <h3>{% trans %}Quick Links{% endtrans %}</h3>
   <ul>
@@ -207,9 +158,3 @@
 </div>
 
 {% endblock %}
-
-
-
-
-
-

--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
-{% set loading_overlay_duration = 18000 %}
+{% set loading_overlay_duration = 3000 %}
+{% set loading_message_duration = 10000 %}
 {% set host = "https://sympy.github.io" %}
 {% set path = "live/repl/" %}
 {% set query = "?toolbar=1&kernel=python" %}
@@ -21,17 +22,20 @@
 
 {% block extrahead %}
 
-<!-- loading overlay -->
+<!-- loading overlay and info message -->
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/gasparesganga-jquery-loading-overlay@2.1.7/dist/loadingoverlay.min.js"></script>
 <script>
   $(document).ready(function() {
     $.LoadingOverlay("show", {
-      text: "SymPy live shell is loading...",
+      text: "Loading SymPy live shell...",
       textResizeFactor: 0.2
     });
     setTimeout(function(){
       $.LoadingOverlay("hide");
     }, {{ loading_overlay_duration }});
+    setTimeout(function(){
+      $('#loading_message').hide();
+    }, {{ loading_message_duration }});
   });
 </script>
 
@@ -92,6 +96,15 @@
 
 {% block content %}
 
+  <div id="loading_message" class="sidebar_card">
+    <div class="content">
+      <p>
+        {% trans %}Note it can take up to 30 seconds before the shell finishes loading and is ready to run commands.{% endtrans %}    
+      </p>
+    </div>
+  </div>
+
+
 
   <h1>SymPy Live</h1>
 
@@ -107,8 +120,7 @@
       <h3>Instructions</h3>
       <div class="content">
         <p>
-          Press <b>SHIFT</b> + <b>ENTER</b> to run the code.<br>
-          On mobile, use the play button (triangle) in the toolbar to run the code.
+          {% trans %}Press ENTER to run the code or use the Run button in the toolbar.{% endtrans %}
         </p>
       </div>
   </div>
@@ -136,7 +148,6 @@
   <p>
     {% trans %}SymPy Live shell allows you to use SymPy in the browser without the need to install anything on your computer.{% endtrans %}
   </p>
-
   <p>
     {% trans %}The following commands are executed by default:{% endtrans %}
     <pre>
@@ -148,10 +159,7 @@
   </p>
   <p>
     {% trans %}SymPy Live shell is powered by{% endtrans %} <a href="https://jupyterlite.readthedocs.io/en/latest/">JupyterLite</a>.
-  </p>
-
-  <p>
-    {% trans %}Note it can take up to 30 seconds before the shell loads and becomes available for using interactively.{% endtrans %}    
+    {% trans %}It can take up to 30 seconds before the shell code and libraries load completely and become available for using interactively.{% endtrans %}    
   </p>
 </div>
 
@@ -192,7 +200,6 @@
     <li><a href="https://github.com/sympy/sympy/issues/">{% trans %}Issues tracker{% endtrans %}</a></li>
     <li><a href="https://github.com/sympy/sympy/wiki">{% trans %}Wiki{% endtrans %}</a></li>
     <li><a href="https://github.com/sympy/sympy/wiki/introduction-to-contributing">{% trans %}Introduction to contributing{% endtrans %}</a></li>
-    <li><a href="https://live.sympy.org/">{% trans %}Try SymPy online now{% endtrans %}</a></li>
     <li><a href="https://planet.sympy.org/">{% trans %}Planet SymPy{% endtrans %}</a></li>
     <li><a href="https://gitter.im/sympy/sympy">{% trans %}Chat (Gitter){% endtrans %}</a></li>
     <li><a href="http://colabti.org/irclogger/irclogger_logs/sympy">{% trans %}IRC channel logs{% endtrans %}</a></li>


### PR DESCRIPTION
This is a derivative PR of the original work by @jptio [PR#169](https://github.com/sympy/sympy.github.com/pull/169).

- [x] (jeremy) Proof of concept use JupyterLite and Pyodide for the online shell [PR169](https://github.com/sympy/sympy.github.com/pull/169)
- [x] (ivan) Changed iframe src to use jinja variables
- [x] (aaron) Merge https://github.com/sympy/sympy-web-static/pull/13
- [x] (aaron) Merge https://github.com/sympy/sympy.github.com/pull/172
- [x] create this PR supersedes PR169
- [x] add init_printing() to the initial list of executed commands
- [x] Edit sidebar to add new "about this page" box to explain that this runs entirely in the browser
- [x] Add support for ?evaluate= query string 
- [x] Add [loading overlay](https://gasparesganga.com/labs/jquery-loading-overlay/) to explain it takes a few seconds to load 
- [x] Make example session match the new console style (use Jupyter inputs [1]: [2]: ).
- [x] Load mathjax in templates/shell.html  (so examples in sidebar can be in LaTeX)

