### PR TITLE
Change hostname from which live shell is loaded

### DIFF
--- a/templates/shell.html
+++ b/templates/shell.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 
-{% set host = "https://sympy.github.io" %}
+{% set host = "https://www.sympy.org" %}
 {% set path = "live/repl/" %}
 {% set query = "?toolbar=1&kernel=python" %}
 {% set code1 = "from sympy import *" %}


### PR DESCRIPTION
There is a problem with the redirect `sympy.github.io --> www.sympy.org`: it drops repeated query string parameters. E.g. `sympy.github.io?code=a&code=b` will get redirected to `www.sympy.org?code=a` dropping the `code=b`.

This PR is a folloup "patach" to https://github.com/sympy/sympy.github.com/pull/174 to change the URL we use for the shell to be `www.sympy.org` so now there are no more redirects and functionality works as expected.