### PR TITLE
Updated lcapy URL

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -71,7 +71,7 @@ project here as well.{% endtrans %}</p>
       {% trans %} Easy LaTeX typesetting of algebraic expressions in symbolic
       form with automatic substitution and result computation). {% endtrans%}
     </li>
-    <li><strong><a href="https://lcapy.elec.canterbury.ac.nz/">
+    <li><strong><a href="https://lcapy.readthedocs.io/en/latest/">
       {% trans %}Lcapy{% endtrans %}</a></strong>:
       {% trans %} Experimental Python package for teaching linear circuit
       analysis. {% endtrans%}


### PR DESCRIPTION
Old URL was broken. Now points at the readthedocs.io documentation.