### PR TITLE
Fix typo in ISSUE_TEMPLATE.md file

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 NOTE: this is the issue tracker for the SymPy website (sympy.org).
 This issue tracker should only be used to report issues with the website specifically.
 
-Issues with SymPy itself should be reported on the SymPy repo https://github.com/sympy/sympy/issues/new
+Issues with SymPy itself should be reported on the SymPy repo: https://github.com/sympy/sympy/issues/new
 This includes issues with SymPy that were found using the SymPy Live shell.
 
 -->


### PR DESCRIPTION
add a colon after `repo` word