### PR TITLE
Fix broken link to Spyder ipythonconsole

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -134,7 +134,7 @@ project here as well.{% endtrans %}</p>
       {% trans %}Spyder{% endtrans %}</a></strong>:
       {% trans %} The Scientific Python Development Environment, a Python
       equivalent to Rstudio or MATLAB; full SymPy support can be enabled in
-      Spyder's <a href="https://docs.spyder-ide.org/ipythonconsole.html">
+      Spyder's <a href="https://docs.spyder-ide.org/current/panes/ipythonconsole.html>
         IPython Consoles</a>.{% endtrans%}
     </li>
     <li><strong><a href="https://www.researchgate.net/publication/260585491_Symbolic_Statistics_with_SymPy/">


### PR DESCRIPTION
Broken link: https://docs.spyder-ide.org/ipythonconsole.html
Correct link: https://docs.spyder-ide.org/current/panes/ipythonconsole.html