### PR TITLE
Fixed wrong copyright year by modifying generate file . Fixes Issue #168

### DIFF
--- a/generate
+++ b/generate
@@ -63,7 +63,7 @@ for language in languages:
             {
                 name + "_active": "active",
                 "static_path": STATIC_PATH,
-                "copyright_year": datetime.datetime.utcnow().year
+                "copyright_year": datetime.datetime.today().year
             }
         )
         os.makedirs(os.path.join('build', language), exist_ok=True)


### PR DESCRIPTION
# Pull Request: Update Copyright Year

## Description

This pull request addresses issue #168 by making necessary changes to the codebase. The primary changes include:

1. Replaced the deprecated `utcnow()` function with the `today()` function to ensure proper handling of the current date.
2. Corrected the copyright year in the generate file.

These changes aim to enhance the website's compatibility and correctness, aligning with best practices for date handling and ensuring accurate representation of the copyright year in generated files.

## Changes Made

- Replaced deprecated `utcnow()` with `today()` for proper year handling in generate file.


