### PR TITLE
Update donation link

### DIFF
--- a/templates/donate.html
+++ b/templates/donate.html
@@ -17,7 +17,7 @@ for hosting costs for services such as the
 
     <section id="get-started">
     <p>{% trans
-    %}<a href="https://numfocus.salsalabs.org/donate-to-sympy/index.html">DONATE
+    %}<a href="https://numfocus.org/donate-to-sympy">DONATE
     NOW</a> {% endtrans %}</p>
   </div>
 </section>


### PR DESCRIPTION
Update donation link from hosted Salsa Labs page (which no longer works) to page hosted on NumFOCUS site.